### PR TITLE
feat: create pagination component

### DIFF
--- a/src/stories/Pagination.stories.tsx
+++ b/src/stories/Pagination.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Pagination from "./Pagination";
+import { Button } from "@mui/material";
+import HomeIcon from "@mui/icons-material/Home";
+
+const meta = {
+  component: Pagination,
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const HideLeft: Story = {
+  args: {
+    leftButton: null, // This hides the left button
+  },
+};
+
+export const HideRight: Story = {
+  args: {
+    rightButton: null,
+  },
+};
+
+export const Home: Story = {
+  args: {
+    rightButton: (
+      <Button variant="contained" startIcon={<HomeIcon />}>
+        Home
+      </Button>
+    ),
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    leftButton: "invalid string",
+  },
+};

--- a/src/stories/Pagination.tsx
+++ b/src/stories/Pagination.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Button } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+
+interface PaginationProps {
+  leftButton?: React.ReactNode | null; // Left button can be custom or null to hide
+  rightButton?: React.ReactNode | null; // Right button can be custom or null to hide
+  onLeftButtonClick?: () => void;
+  onRightButtonClick?: () => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  leftButton = (
+    <Button variant="outlined" startIcon={<ChevronLeftIcon />}>
+      Prev
+    </Button>
+  ),
+  rightButton = (
+    <Button variant="outlined" endIcon={<ChevronRightIcon />}>
+      Next
+    </Button>
+  ),
+  onLeftButtonClick,
+  onRightButtonClick,
+}) => {
+  const validateButton = (button: React.ReactNode | null) => {
+    if (button === null) {
+      return null;
+    }
+
+    // Check if the button is a valid React element (e.g. Button)
+    if (React.isValidElement(button)) {
+      return button;
+    }
+
+    // If it's an invalid string or anything else, return null
+    return null;
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 20,
+        width: "90%",
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "2 2px",
+      }}
+    >
+      {/* Left Button */}
+      {validateButton(leftButton) !== null && (
+        <div style={{ flex: 1, display: "flex", justifyContent: "flex-start" }}>
+          <div onClick={onLeftButtonClick}>{leftButton}</div>
+        </div>
+      )}
+
+      {/* Right Button */}
+      {validateButton(rightButton) !== null && (
+        <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+          <div onClick={onRightButtonClick}>{rightButton}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
Closes: Issue #11 
### Summary
Created a Pagination component with customizable left and right buttons. Default buttons are "Prev" (left) and "Next" (right).Buttons can be hidden by passing `null`. Invalid strings or values are ignored.

### Modifications
Pagination Component:
- `leftButton` and `rightButton` props accept custom buttons or `null` to hide.
- Defaults to "Prev" (left) and "Next" (right).

### Example Usage:
Prev button on left & Home button on right:
```
<Pagination 
  rightButton={<Button variant="contained" startIcon={<HomeIcon />}> Home </Button>} 
  onLeftButtonClick={handleLeftClick} 
  onRightButtonClick={handleRightClick}
/>
```
Only render Next button on the right:
```
<Pagination 
  leftButton={null} 
  onLeftButtonClick={handleLeftClick} 
  onRightButtonClick={handleRightClick}
/>
```
### Notes:
- Ensures correct alignment even when a button is hidden.
- Invalid button values will be treated as null