### PR TITLE
added home button for scan and learn

### DIFF
--- a/src/stories/LearnGuidePage.tsx
+++ b/src/stories/LearnGuidePage.tsx
@@ -3,7 +3,8 @@ import BottomNavBar from "./BottomNavBar";
 import { Step } from "./Step";
 import { Topbar } from "./Topbar";
 import { useState } from "react";
-import { ArrowBackIos, ArrowForwardIos } from "@mui/icons-material";
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { LearnFeedback } from "./LearnFeedback";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -119,7 +120,7 @@ export const LearnGuidePage = () => {
           }
           variant="outlined"
           sx={{ color: "black", borderColor: "black" }}
-          startIcon={<ArrowBackIos></ArrowBackIos>}
+          startIcon={<ArrowBackIosNewIcon></ArrowBackIosNewIcon>}
         >
           Prev
         </Button>
@@ -127,7 +128,7 @@ export const LearnGuidePage = () => {
           onClick={handleNextPage}
           sx={{ color: "black", borderColor: "black" }}
           variant="outlined"
-          endIcon={<ArrowForwardIos></ArrowForwardIos>}
+          endIcon={<ArrowForwardIosIcon></ArrowForwardIosIcon>}
         >
           {feedback ? "Finish" : "Next"}
         </Button>

--- a/src/stories/LearnGuidePage.tsx
+++ b/src/stories/LearnGuidePage.tsx
@@ -3,8 +3,8 @@ import BottomNavBar from "./BottomNavBar";
 import { Step } from "./Step";
 import { Topbar } from "./Topbar";
 import { useState } from "react";
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import { LearnFeedback } from "./LearnFeedback";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/stories/LearnGuidePage.tsx
+++ b/src/stories/LearnGuidePage.tsx
@@ -79,10 +79,7 @@ export const LearnGuidePage = () => {
 
   return (
     <>
-      <Topbar
-        title="Learn"
-        leftButtonText="HomeIcon"
-      ></Topbar>
+      <Topbar title="Learn" leftButtonText="HomeIcon"></Topbar>
       <Box
         sx={{
           height: "80dvh",
@@ -109,16 +106,22 @@ export const LearnGuidePage = () => {
         </Box>
         <LearnFeedback visible={feedback} />
       </Box>
-      <Box sx={{ display: "flex", justifyContent: "space-between", pl: 2, pr: 2}}>
-      <Button onClick={          page == 0
-            ? () => {
-                void navigation(`/learn/${carId}/${systemId}`);
-              }
-            : handlePreviousPage}
-            variant="outlined"
-            sx={{ color: "black", borderColor: "black" }}
-            startIcon={<ArrowBackIos></ArrowBackIos>}>
-          Previous
+      <Box
+        sx={{ display: "flex", justifyContent: "space-between", pl: 2, pr: 2 }}
+      >
+        <Button
+          onClick={
+            page == 0
+              ? () => {
+                  void navigation(`/learn/${carId}/${systemId}`);
+                }
+              : handlePreviousPage
+          }
+          variant="outlined"
+          sx={{ color: "black", borderColor: "black" }}
+          startIcon={<ArrowBackIos></ArrowBackIos>}
+        >
+          Prev
         </Button>
         <Button
           onClick={handleNextPage}
@@ -128,7 +131,6 @@ export const LearnGuidePage = () => {
         >
           {feedback ? "Finish" : "Next"}
         </Button>
-
       </Box>
 
       <BottomNavBar></BottomNavBar>

--- a/src/stories/LearnGuidePage.tsx
+++ b/src/stories/LearnGuidePage.tsx
@@ -3,7 +3,7 @@ import BottomNavBar from "./BottomNavBar";
 import { Step } from "./Step";
 import { Topbar } from "./Topbar";
 import { useState } from "react";
-import { ArrowForwardIos } from "@mui/icons-material";
+import { ArrowBackIos, ArrowForwardIos } from "@mui/icons-material";
 import { LearnFeedback } from "./LearnFeedback";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -81,14 +81,7 @@ export const LearnGuidePage = () => {
     <>
       <Topbar
         title="Learn"
-        leftButtonText="BackIcon"
-        leftButtonAction={
-          page == 0
-            ? () => {
-                void navigation(`/learn/${carId}/${systemId}`);
-              }
-            : handlePreviousPage
-        }
+        leftButtonText="HomeIcon"
       ></Topbar>
       <Box
         sx={{
@@ -116,15 +109,26 @@ export const LearnGuidePage = () => {
         </Box>
         <LearnFeedback visible={feedback} />
       </Box>
-      <Box sx={{ display: "flex", justifyContent: "end" }}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", pl: 2, pr: 2}}>
+      <Button onClick={          page == 0
+            ? () => {
+                void navigation(`/learn/${carId}/${systemId}`);
+              }
+            : handlePreviousPage}
+            variant="outlined"
+            sx={{ color: "black", borderColor: "black" }}
+            startIcon={<ArrowBackIos></ArrowBackIos>}>
+          Previous
+        </Button>
         <Button
           onClick={handleNextPage}
-          sx={{ alignSelf: "end", color: "black", borderColor: "black" }}
+          sx={{ color: "black", borderColor: "black" }}
           variant="outlined"
           endIcon={<ArrowForwardIos></ArrowForwardIos>}
         >
           {feedback ? "Finish" : "Next"}
         </Button>
+
       </Box>
 
       <BottomNavBar></BottomNavBar>

--- a/src/stories/SelectCarPage.tsx
+++ b/src/stories/SelectCarPage.tsx
@@ -161,7 +161,7 @@ export const SelectCarPage = () => {
 
   return (
     <>
-      <Topbar title="Learn" />
+      <Topbar title="Learn" leftButtonText="HomeIcon"/>
       <Box
         sx={{
           width: "100vw",

--- a/src/stories/SelectCarPage.tsx
+++ b/src/stories/SelectCarPage.tsx
@@ -161,7 +161,7 @@ export const SelectCarPage = () => {
 
   return (
     <>
-      <Topbar title="Learn" leftButtonText="HomeIcon"/>
+      <Topbar title="Learn" leftButtonText="HomeIcon" />
       <Box
         sx={{
           width: "100vw",

--- a/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
+++ b/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
@@ -37,10 +37,7 @@ const CaptureSafteyEquipmentScreen: React.FC = () => {
 
   return (
     <Box width="100vw">
-      <Topbar 
-        title="Safety Verification" 
-        leftButtonText="HomeIcon"
-        />
+      <Topbar title="Safety Verification" leftButtonText="HomeIcon" />
       <CameraView
         onCapture={() => {
           setOpen(true);

--- a/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
+++ b/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
@@ -7,7 +7,7 @@ import { Box } from "@mui/material";
 const CaptureSafteyEquipmentScreen: React.FC = () => {
   return (
     <Box width="100vw">
-      <Topbar title="Take a Photo of Your Safety Equipment" />
+      <Topbar title="Take a Photo of Your Safety Equipment" leftButtonText="HomeIcon"/>
       <CameraView />
       <BottomNavBar />
     </Box>

--- a/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
+++ b/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
@@ -7,7 +7,10 @@ import { Box } from "@mui/material";
 const CaptureSafteyEquipmentScreen: React.FC = () => {
   return (
     <Box width="100vw">
-      <Topbar title="Take a Photo of Your Safety Equipment" leftButtonText="HomeIcon"/>
+      <Topbar
+        title="Take a Photo of Your Safety Equipment"
+        leftButtonText="HomeIcon"
+      />
       <CameraView />
       <BottomNavBar />
     </Box>

--- a/src/stories/flows/do/ChecklistScreen.tsx
+++ b/src/stories/flows/do/ChecklistScreen.tsx
@@ -19,7 +19,7 @@ const ChecklistScreen: React.FC = () => {
 
   return (
     <>
-      <Topbar title="Required Tools" />
+      <Topbar title="Required Tools" leftButtonText="HomeIcon"/>
       <Box
         sx={{
           display: "flex",

--- a/src/stories/flows/do/ChecklistScreen.tsx
+++ b/src/stories/flows/do/ChecklistScreen.tsx
@@ -19,7 +19,7 @@ const ChecklistScreen: React.FC = () => {
 
   return (
     <>
-      <Topbar title="Required Tools" leftButtonText="HomeIcon"/>
+      <Topbar title="Required Tools" leftButtonText="HomeIcon" />
       <Box
         sx={{
           display: "flex",

--- a/src/stories/flows/do/ScanQrCodeScreen.tsx
+++ b/src/stories/flows/do/ScanQrCodeScreen.tsx
@@ -12,7 +12,10 @@ export function ScanQrCodeScreen() {
 
   return (
     <>
-      <Topbar title="Scan the QR Code on Your Product's Package" leftButtonText="HomeIcon" />
+      <Topbar
+        title="Scan the QR Code on Your Product's Package"
+        leftButtonText="HomeIcon"
+      />
       <Box
         sx={{
           flexGrow: 1,

--- a/src/stories/flows/do/ScanQrCodeScreen.tsx
+++ b/src/stories/flows/do/ScanQrCodeScreen.tsx
@@ -12,7 +12,7 @@ export function ScanQrCodeScreen() {
 
   return (
     <>
-      <Topbar title="Scan the QR Code on Your Product's Package" />
+      <Topbar title="Scan the QR Code on Your Product's Package" leftButtonText="HomeIcon" />
       <Box
         sx={{
           flexGrow: 1,

--- a/src/stories/flows/do/StepPage.tsx
+++ b/src/stories/flows/do/StepPage.tsx
@@ -20,7 +20,7 @@ const StepPage: React.FC<StepPageProps> = (props: StepPageProps) => {
 
   return (
     <>
-      <Topbar title={props.title} />
+      <Topbar title={props.title} leftButtonText="HomeIcon"/>
       <Step
         image={props.image}
         caption={props.caption}

--- a/src/stories/flows/do/StepPage.tsx
+++ b/src/stories/flows/do/StepPage.tsx
@@ -20,7 +20,7 @@ const StepPage: React.FC<StepPageProps> = (props: StepPageProps) => {
 
   return (
     <>
-      <Topbar title={props.title} leftButtonText="HomeIcon"/>
+      <Topbar title={props.title} leftButtonText="HomeIcon" />
       <Step
         image={props.image}
         caption={props.caption}

--- a/src/stories/flows/do/StepValidationScreen.tsx
+++ b/src/stories/flows/do/StepValidationScreen.tsx
@@ -23,7 +23,7 @@ const StepValidationScreen: React.FC = () => {
 
   return (
     <>
-      <Topbar title="Step 3: Validate your System" />
+      <Topbar title="Step 3: Validate your System" leftButtonText="HomeIcon" />
 
       <Box
         sx={{


### PR DESCRIPTION
- added home buttons for pages in the learn and do workflow
- standardized next and previous buttons so that it's the same between the learn and do
![image](https://github.com/user-attachments/assets/6840006a-9b53-4ce4-8c92-cdfd328c65f0)
![image](https://github.com/user-attachments/assets/bd23aa1b-d591-45b5-bcf6-a566a0461b26)


