### PR TITLE
feat: safety instructions

### DIFF
--- a/src/stories/CameraView.stories.tsx
+++ b/src/stories/CameraView.stories.tsx
@@ -16,4 +16,3 @@ export const Default: Story = {
     onCapture: () => {},
   },
 };
-

--- a/src/stories/CameraView.stories.tsx
+++ b/src/stories/CameraView.stories.tsx
@@ -3,20 +3,17 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { CameraView } from "./CameraView";
 
 const meta = {
-  title: "CameraView",
   component: CameraView,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ["autodocs"],
-  parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
-    layout: "fullscreen",
-  },
-  argTypes: {
-    setState: { type: "function", control: false },
-  },
 } satisfies Meta<typeof CameraView>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    onCapture: () => {},
+  },
+};
+

--- a/src/stories/CameraView.tsx
+++ b/src/stories/CameraView.tsx
@@ -1,8 +1,6 @@
 import { Box, Button } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import Webcam from "react-webcam";
-import Paths from "./flows/paths";
 
 const videoConstraints = {
   width: 1280,

--- a/src/stories/CameraView.tsx
+++ b/src/stories/CameraView.tsx
@@ -9,7 +9,7 @@ const videoConstraints = {
   height: 720,
   facingMode: "user",
 };
-export function CameraView() {
+export function CameraView({ onCapture }: { onCapture: () => void }) {
   const webcamRef = useRef<Webcam>(null);
   const outerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -31,7 +31,8 @@ export function CameraView() {
   const capture = useCallback(() => {
     // this function returns a photo if we want it
     webcamRef.current?.getScreenshot();
-  }, [webcamRef]);
+    onCapture();
+  }, [webcamRef, onCapture]);
   return (
     <Box ref={outerRef} sx={{ height: "100vh" }}>
       <Box height="10%" />
@@ -51,12 +52,7 @@ export function CameraView() {
           justifyContent: "center",
         }}
       >
-        <Button
-          component={Link}
-          to={Paths.checklist}
-          variant="contained"
-          onClick={capture}
-        >
+        <Button variant="contained" onClick={capture}>
           Capture photo
         </Button>
       </Box>

--- a/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
+++ b/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
@@ -2,13 +2,48 @@ import React from "react";
 import { Topbar } from "../../Topbar";
 import { CameraView } from "../../CameraView";
 import BottomNavBar from "../../BottomNavBar";
-import { Box } from "@mui/material";
+import { Alert, Box, Snackbar, SnackbarCloseReason } from "@mui/material";
+import Paths from "../paths";
+import { useNavigate } from "react-router-dom";
 
 const CaptureSafteyEquipmentScreen: React.FC = () => {
+  const nav = useNavigate();
+  const [open, setOpen] = React.useState(false);
+
+  const handleClose = (
+    _event?: React.SyntheticEvent | Event,
+    reason?: SnackbarCloseReason,
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpen(false);
+  };
   return (
     <Box width="100vw">
       <Topbar title="Take a Photo of Your Safety Equipment" />
-      <CameraView />
+      <CameraView
+        onCapture={() => {
+          setOpen(true);
+        }}
+      />
+      <Snackbar
+        open={open}
+        autoHideDuration={3000}
+        onClose={() => {
+          void nav(Paths.checklist);
+        }}
+      >
+        <Alert
+          onClose={handleClose}
+          severity="success"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          Your saftey equipment has been verified
+        </Alert>
+      </Snackbar>
       <BottomNavBar />
     </Box>
   );

--- a/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
+++ b/src/stories/flows/do/CaptureSafteyEquipmentScreen.tsx
@@ -1,14 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { Topbar } from "../../Topbar";
 import { CameraView } from "../../CameraView";
 import BottomNavBar from "../../BottomNavBar";
-import { Alert, Box, Snackbar, SnackbarCloseReason } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Snackbar,
+  SnackbarCloseReason,
+} from "@mui/material";
 import Paths from "../paths";
 import { useNavigate } from "react-router-dom";
 
 const CaptureSafteyEquipmentScreen: React.FC = () => {
   const nav = useNavigate();
-  const [open, setOpen] = React.useState(false);
+
+  const [open, setOpen] = useState(false);
+  const [openSuccess, setOpenSuccess] = useState(false);
+  const [openDialog, setOpenDialog] = useState(true);
 
   const handleClose = (
     _event?: React.SyntheticEvent | Event,
@@ -20,9 +34,10 @@ const CaptureSafteyEquipmentScreen: React.FC = () => {
 
     setOpen(false);
   };
+
   return (
     <Box width="100vw">
-      <Topbar title="Take a Photo of Your Safety Equipment" />
+      <Topbar title="Safety Verification" />
       <CameraView
         onCapture={() => {
           setOpen(true);
@@ -31,6 +46,22 @@ const CaptureSafteyEquipmentScreen: React.FC = () => {
       <Snackbar
         open={open}
         autoHideDuration={3000}
+        onClose={() => {
+          setOpenSuccess(true);
+        }}
+      >
+        <Alert
+          onClose={handleClose}
+          severity="info"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          Verifying your saftey equipment...
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={openSuccess}
+        autoHideDuration={1000}
         onClose={() => {
           void nav(Paths.checklist);
         }}
@@ -41,9 +72,33 @@ const CaptureSafteyEquipmentScreen: React.FC = () => {
           variant="filled"
           sx={{ width: "100%" }}
         >
-          Your saftey equipment has been verified
+          Verified!
         </Alert>
       </Snackbar>
+      <Dialog
+        open={openDialog}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Verify Your Saftey Equipment"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Take a photo of your saftey equipment so that we can verify you have
+            everything to need to continue safely.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setOpenDialog(false);
+            }}
+          >
+            Continue
+          </Button>
+        </DialogActions>
+      </Dialog>
       <BottomNavBar />
     </Box>
   );


### PR DESCRIPTION
closes #70 

to test, `npm run dev` and then go to `/instructions/safety` (you could go through the flow too but this skips to the right part)

i added
1. a dialog open by default that gives instructions
1. a snackbar after picture is taken that says we are verifying
1. a snackbar after a fixed time from 3 that says it was verified navigates to next page once 